### PR TITLE
add marker file to allow mypy to discover type annotations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['test', 'test.*']),
     package_data={
         'qudt.ontology.resources': ['*'],
+        'qudt': ['py.typed'],
     },
     install_requires=[
         'PyLD',


### PR DESCRIPTION
Thanks for the library! Quick enhancement: 

Per [PEP 561](https://www.python.org/dev/peps/pep-0561/) this is the magic invocation to allow `mypy` to pick up the type annotations in this lib when its installed and used by other projects. 