### PR TITLE
fix pip install when setuptools>=58 (drop python 3.6 support)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 PyLD ~= 2.0.1
-rdflib ~= 5.0.0
-rdflib-jsonld ~= 0.5.0
+rdflib ~= 6.0.1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setuptools.setup(
     classifiers=[
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Topic :: Scientific/Engineering',
@@ -40,6 +39,7 @@ setuptools.setup(
         'Topic :: Scientific/Engineering :: Chemistry',
         'Topic :: Scientific/Engineering :: Physics',
     ],
+    python_requires='>=3.7',
     packages=setuptools.find_packages(exclude=['test', 'test.*']),
     package_data={
         'qudt.ontology.resources': ['*'],


### PR DESCRIPTION
`rdflib-jsonld==0.5.0` no longer installs with setuputils versions 58 and up. This PR upgrades the dependency and drops support for python 3.6, since rdflib 6.x already has. 

Both the tests in this repo and a second set of tests covering my usage of this package pass with this version bump. 

This fixes error messages like these when running `pip install`: 


```
Collecting rdflib-jsonld==0.5.0
  Downloading rdflib-jsonld-0.5.0.tar.gz (55 kB)
    ERROR: Command errored out with exit status 1:
     command: /run-tests/.tox/py37/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-73obvhya/rdflib-jsonld_a1249dd12dc94d389db59c24469d0c42/setup.py'"'"'; __file__='"'"'/tmp/pip-install-73obvhya/rdflib-jsonld_a1249dd12dc94d389db59c24469d0c42/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-5wd_mche
         cwd: /tmp/pip-install-73obvhya/rdflib-jsonld_a1249dd12dc94d389db59c24469d0c42/
    Complete output (1 lines):
    error in rdflib-jsonld setup command: use_2to3 is invalid.
```